### PR TITLE
OCPBUGS-25662: ecr-credential-provider RPM CI builds

### DIFF
--- a/ecr-credential-provider.spec
+++ b/ecr-credential-provider.spec
@@ -47,7 +47,7 @@
 %global golang_version 1.21.0
 %{!?version: %global version 0.0.1}
 %{!?release: %global release 1}
-%global package_name ecr-credential-provider 
+%global package_name ecr-credential-provider
 %global product_name ecr-credential-provider
 
 Name:           %{package_name}
@@ -56,7 +56,7 @@ Release:        %{release}%{?dist}
 Summary:        AWS ecr kubelet image credential provider
 License:        ASL 2.0
 
-Source0:        %{name}-%{version}.tar.gz
+Source0:        %{name}.tar.gz
 BuildRequires:  bsdtar
 BuildRequires:  golang >= %{golang_version}
 

--- a/openshift-hack/build-rpm.sh
+++ b/openshift-hack/build-rpm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+
+source_path=_output/SOURCES
+
+mkdir -p ${source_path}
+
+# Getting version from args
+version=${1:-4.14.0}
+
+# Trick to make sure we'll install this RPM later on, not the one from the repo.
+release=999999999999
+
+# NOTE:        rpmbuild requires that inside the tar there will be a
+#              ${service}-${version} directory, hence this --transform option.
+#              We exclude .git as rpmbuild will do its own `git init`.
+#              Excluding .tox is convenient for local builds.
+tar -czvf ${source_path}/ecr-credential-provider.tar.gz --exclude=.git --exclude=.tox --transform "flags=r;s|\.|ecr-credential-provider-${version}|" .
+
+
+rpmbuild -ba -D "_version $version" -D "_release $release" -D "_topdir `pwd`/_output" ecr-credential-provider.spec
+# TODO: We might need to change this
+createrepo _output/RPMS/noarch


### PR DESCRIPTION
This is a first attempt at putting the correct prerequisites in place to build the ecr-credential-provider rpm in CI.

We may need changes down the line, but I'm not aware of a way to tell CI to use this branch. 