### PR TITLE
OCPBUGS-25662: Installs ecr-credential-provider to /usr/libexec

### DIFF
--- a/ecr-credential-provider.spec
+++ b/ecr-credential-provider.spec
@@ -125,18 +125,18 @@ VERSION=v${OS_GIT_VERSION} make ecr-credential-provider
 %install
 
 PLATFORM="$(go env GOHOSTOS)-$(go env GOHOSTARCH)"
-install -d %{buildroot}%{_bindir}
+install -d %{buildroot}%{_libexecdir}/kubelet-image-credential-provider-plugins
 
 # Install linux components
 for bin in ecr-credential-provider 
 do
   echo "+++ INSTALLING ${bin}"
-  install -p -m 755 %{_builddir}/%{name}-%{version}/${bin} %{buildroot}%{_bindir}/${bin}
+  install -p -m 755 %{_builddir}/%{name}-%{version}/${bin} %{buildroot}%{_libexecdir}/kubelet-image-credential-provider-plugins/${bin}
 done
 
 %files
 %license LICENSE
-%{_bindir}/ecr-credential-provider
+%{_libexecdir}/kubelet-image-credential-provider-plugins/ecr-credential-provider
 
 %pre
 


### PR DESCRIPTION
This change moves the install directory to /usr/libexec, rather than /usr/bin.

This is because it is a requirement for kubelet, and not intended to be interacted with by a user.