### PR TITLE
OCPBUGS-25662: Updates rpm build script

### DIFF
--- a/ecr-credential-provider.spec
+++ b/ecr-credential-provider.spec
@@ -9,7 +9,7 @@
 # modifying the Go binaries breaks the DWARF debugging
 %global __os_install_post %{_rpmconfigdir}/brp-compress
 
-# %commit and %os_git_vars are intended to be set by tito custom builders
+# %commit and os_git_vars are intended to be set by tito custom builders
 # provided in the .tito/lib directory. The values in this spec file will not be
 # kept up to date.
 %{!?commit: %global commit HEAD }

--- a/openshift-hack/build-rpm.sh
+++ b/openshift-hack/build-rpm.sh
@@ -7,6 +7,10 @@ mkdir -p ${source_path}
 # Getting version from args
 version=${1:-4.14.0}
 
+# Install dependencies required
+dnf install -y rpmdevtools
+dnf install -y createrepo
+dnf builddep -y ecr-credential-provider.spec
 # Trick to make sure we'll install this RPM later on, not the one from the repo.
 release=999999999999
 
@@ -14,9 +18,9 @@ release=999999999999
 #              ${service}-${version} directory, hence this --transform option.
 #              We exclude .git as rpmbuild will do its own `git init`.
 #              Excluding .tox is convenient for local builds.
-tar -czvf ${source_path}/ecr-credential-provider.tar.gz --exclude=.git --exclude=.tox --transform "flags=r;s|\.|ecr-credential-provider-${version}|" .
+tar -czf ${source_path}/ecr-credential-provider.tar.gz --exclude=.git --exclude=.tox --transform "flags=r;s|\.|ecr-credential-provider-${version}|" .
 
 
-rpmbuild -ba -D "_version $version" -D "_release $release" -D "_topdir `pwd`/_output" ecr-credential-provider.spec
-# TODO: We might need to change this
-createrepo _output/RPMS/noarch
+rpmbuild -ba -D "version $version" -D "release $release" -D "os_git_vars OS_GIT_VERSION=$version" -D "_topdir \`pwd\`/_output" ecr-credential-provider.spec
+
+createrepo _output/RPMS/x86_64


### PR DESCRIPTION
Updates the build-rpm script to:

- Install dependencies for the build process,
- Install dependencies of the .spec,
- Quiet tar compression (remove -v)
- Override the `OS_GIT_VERSION`
- Update the output repo to contain the arch, `x86x64`

It also updates ecr-credential-provider.spec to not expand the
`os_git_vars` macro in a comment, so our override of `OS_GIT_VERSION` works.