### PR TITLE
OCPBUGS-28548: spec: add `Provides: ose-aws-ecr-image-credential-provider`

### DIFF
--- a/ecr-credential-provider.spec
+++ b/ecr-credential-provider.spec
@@ -59,6 +59,7 @@ License:        ASL 2.0
 Source0:        %{name}.tar.gz
 BuildRequires:  bsdtar
 BuildRequires:  golang >= %{golang_version}
+Provides:       ose-aws-ecr-image-credential-provider = %{version}-%{release}
 
 # If go_arches not defined fall through to implicit golang archs
 %if 0%{?go_arches:1}


### PR DESCRIPTION
So CI can seamlessly upgrade the base OS image during testing.

Related to:
- https://github.com/openshift/release/pull/48266
- https://github.com/openshift/release/pull/48208