### PR TITLE
Revert "log useful information about the cluster and the instance

### DIFF
--- a/pkg/providers/v1/aws.go
+++ b/pkg/providers/v1/aws.go
@@ -681,14 +681,6 @@ func (c *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	c.eventBroadcaster.StartStructuredLogging(0)
 	c.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.kubeClient.CoreV1().Events("")})
 	c.eventRecorder = c.eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "aws-cloud-provider"})
-
-	v, err := c.kubeClient.Discovery().ServerVersion()
-	if err != nil {
-		klog.Errorf("Error looking up cluster version: %q", err)
-	} else {
-		klog.Infof("cluster version: v%s.%s. git version: %s. git tree state: %s. commit: %s. platform: %s",
-			v.Major, v.Minor, v.GitVersion, v.GitTreeState, v.GitCommit, v.Platform)
-	}
 }
 
 // Clusters returns the list of clusters.

--- a/pkg/providers/v1/aws_sdk.go
+++ b/pkg/providers/v1/aws_sdk.go
@@ -31,7 +31,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"k8s.io/client-go/pkg/version"
-	"k8s.io/klog/v2"
 
 	"k8s.io/cloud-provider-aws/pkg/providers/v1/config"
 	"k8s.io/cloud-provider-aws/pkg/providers/v1/iface"
@@ -209,20 +208,6 @@ func (p *awsSDKProvider) Metadata() (config.EC2Metadata, error) {
 	}
 	client := ec2metadata.New(sess)
 	p.addAPILoggingHandlers(&client.Handlers)
-
-	identity, err := client.GetInstanceIdentityDocument()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get instance identity document: %v", err)
-	}
-	klog.InfoS("instance metadata identity",
-		"region", identity.Region,
-		"availability-zone", identity.AvailabilityZone,
-		"instance-type", identity.InstanceType,
-		"architecture", identity.Architecture,
-		"instance-id", identity.InstanceID,
-		"private-ip", identity.PrivateIP,
-		"account-id", identity.AccountID,
-		"image-id", identity.ImageID)
 	return client, nil
 }
 


### PR DESCRIPTION
This reverts commit 7a4b3094ffb7a12760dd5603eec46ff868695f32.

This commit broke hypershift as it assumes the CCM runs in the same account as the Nodes, which is not true on HCP.