### PR TITLE
DNM/SPLAT-2253: feat: create NLB with security groups through config

### DIFF
--- a/pkg/providers/v1/aws_loadbalancer.go
+++ b/pkg/providers/v1/aws_loadbalancer.go
@@ -141,7 +141,7 @@ func getKeyValuePropertiesFromAnnotation(annotations map[string]string, annotati
 }
 
 // ensureLoadBalancerv2 ensures a v2 load balancer is created
-func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, discoveredSubnetIDs []string, internalELB bool, annotations map[string]string) (*elbv2.LoadBalancer, error) {
+func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, discoveredSubnetIDs []string, internalELB bool, annotations map[string]string, securityGroups []*string) (*elbv2.LoadBalancer, error) {
 	loadBalancer, err := c.describeLoadBalancerv2(loadBalancerName)
 	if err != nil {
 		return nil, err
@@ -176,6 +176,9 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 		// We are supposed to specify one subnet per AZ.
 		// TODO: What happens if we have more than one subnet per AZ?
 		createRequest.SubnetMappings = createSubnetMappings(discoveredSubnetIDs, allocationIDs)
+
+		// Enable provisioning NLB with security groups when the annotation(s) are set.
+		createRequest.SecurityGroups = securityGroups
 
 		for k, v := range tags {
 			createRequest.Tags = append(createRequest.Tags, &elbv2.Tag{

--- a/pkg/providers/v1/config/config.go
+++ b/pkg/providers/v1/config/config.go
@@ -17,6 +17,12 @@ const (
 
 	// ClusterServiceLoadBalancerHealthProbeModeServiceNodePort is the service node port health probe mode for cluster service load balancer.
 	ClusterServiceLoadBalancerHealthProbeModeServiceNodePort = "ServiceNodePort"
+
+	// NLBSecurityGroupModeManaged indicates the controller is managing security groups on service type loadbalancer NLB.
+	NLBSecurityGroupModeManaged = "Managed"
+
+	// NLBSecurityGroupModeUnmanaged indicates the controller is not managing security groups on service type loadbalancer NLB.
+	NLBSecurityGroupModeUnmanaged = "Unmanaged"
 )
 
 // CloudConfig wraps the settings for the AWS cloud provider.
@@ -83,6 +89,10 @@ type CloudConfig struct {
 
 		// ClusterServiceSharedLoadBalancerHealthProbePath defines the target path of the shared health probe. Default to `/healthz`.
 		ClusterServiceSharedLoadBalancerHealthProbePath string `json:"clusterServiceSharedLoadBalancerHealthProbePath,omitempty" yaml:"clusterServiceSharedLoadBalancerHealthProbePath,omitempty"`
+
+		// NLBSecurityGroupMode determines if the controller manage, creates and attaches, the security group when the service type
+		// loadbalancer NLB is created.
+		NLBSecurityGroupMode string `json:"nlbSecurityGroupMode,omitempty" yaml:"nlbSecurityGroupMode,omitempty"`
 	}
 	// [ServiceOverride "1"]
 	//  Service = s3


### PR DESCRIPTION
This feature introduce ability to CCM to crate service type loadbalancer NLB with security group through cloud config.

This is a spike/exploration/validation in downstream to build with cluster-bot, the final solutions is TBD.

Cluster-bot build cmd: TBD