### PR TITLE
OCPCLOUD-3341: Updates ecr-credential-provider make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ aws-cloud-controller-manager:
 		cmd/aws-cloud-controller-manager/main.go
 
 .PHONY: ecr-credential-provider
+ecr-credential-provider: LDFLAGS = -w -s -X k8s.io/component-base/version.gitVersion=$(VERSION) -X main.gitVersion=$(VERSION)
 ecr-credential-provider:
 	 GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) GOPROXY=$(GOPROXY) go build \
 		-trimpath \


### PR DESCRIPTION
Don't read LDFLAGS from env, in brew we set C specific flags that cause the build to break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the ECR credential provider target to explicitly set per-target linker flags so the built binary includes the correct version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->