### PR TITLE
OCPBUGS-93205: UPSTREAM: <carry>: Bump go directive to 1.26.4 for CVE-2026-42504

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-aws/tests/e2e
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6


### PR DESCRIPTION
The Go standard library mime.WordDecoder.DecodeHeader has a quadratic complexity DoS vulnerability (CVE-2026-42504, GO-2026-5038, CVSS 7.5 HIGH) that is fixed in Go 1.26.4. Call graph analysis confirms the vulnerable function is reachable from main() through the Kubernetes REST client warning header parsing path.

Upstream (kubernetes/cloud-provider-aws) is currently on go 1.26.0. The Go 1.26.4 RPM for RHEL is in "Release Pending" status ([RHEL-183349](https://redhat.atlassian.net/browse/RHEL-183349)), after which ART will update the builder image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to `1.26.4` (from `1.26.0`) in both the main module and the end-to-end test module.
  * No changes to application behavior or any other dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->